### PR TITLE
Updating implementation --> compile

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,10 +37,10 @@ dependencies {
     implementation 'com.android.support:cardview-v7:26.1.0'
     implementation 'com.android.support:recyclerview-v7:26.1.0'
     implementation 'pub.devrel:easypermissions:0.3.0'
-    compile('com.google.api-client:google-api-client-android:1.23.0') {
+    implementation('com.google.api-client:google-api-client-android:1.23.0') {
         exclude group: 'org.apache.httpcomponents'
     }
-    compile('com.google.apis:google-api-services-sheets:v4-rev511-1.23.0') {
+    implementation('com.google.apis:google-api-services-sheets:v4-rev511-1.23.0') {
         exclude group: 'org.apache.httpcomponents'
     }
 


### PR DESCRIPTION
New andorid update requires that all lines in the build.gradle that contain "compile" are replaced with "implementation." Got tired of seeing the warning.